### PR TITLE
Property group markup mistake prevention

### DIFF
--- a/generate-syntax.py
+++ b/generate-syntax.py
@@ -58,7 +58,7 @@ _KNOWN_PAIR_PATTERN_TEMPLATE = r'''
     "match": "(__KEY__)\\s*__SEP__\\s*((__VALUE_REGEX__)[^__TERM__\\s]+)",
     "captures": {
         "1": { "name": "__STYLE_PROP_NAME__" },
-        "2": { "name": "__STYLE_PROP_WRONG_VALUE__" }
+        "2": { "name": "__STYLE_INVALID__" }
     }
 },
 {
@@ -67,7 +67,7 @@ _KNOWN_PAIR_PATTERN_TEMPLATE = r'''
         "1": { "name": "__STYLE_PROP_NAME__" },
         "3": { "name": "__STYLE_PROP_VALUE__" },
         "4": { "name": "__STYLE_VARIABLE__" },
-        "__WRONG_VALUE_INDEX__": { "name": "__STYLE_PROP_WRONG_VALUE__" }
+        "__WRONG_VALUE_INDEX__": { "name": "__STYLE_INVALID__" }
     }
 }'''
 
@@ -96,7 +96,7 @@ _EXPRESSION_PATTERNS = r'''
     "name": "__STYLE_LENGTH__",
     "match": "[+-]?([0-9]*[.])?[0-9]+(pw|ph|cw|ch|mt|mr|mb|ml|sbh|eb|%)?",
     "captures": {
-        "4": "__STYLE_PROP_WRONG_VALUE__"
+        "4": "__STYLE_INVALID__"
     }
 }
 '''
@@ -128,8 +128,8 @@ _STYLE_MAP = {
     # common styles
     '__STYLE_PROP_NAME__':          'entity.other.attribute-name',
     '__STYLE_PROP_VALUE__':         'string',
-    '__STYLE_PROP_WRONG_VALUE__':   'invalid.illegal',
     '__STYLE_PROP_SEP__':           'keyword.operator',
+    '__STYLE_INVALID__':            'invalid.illegal',
     '__STYLE_VARIABLE__':           'string markup.italic',
     '__STYLE_FILENAME__':           'string',
     '__STYLE_LENGTH__':             'constant.numeric',

--- a/sbss.tmLanguage.template.json
+++ b/sbss.tmLanguage.template.json
@@ -84,6 +84,11 @@
         },
         "property-group": {
             "patterns": [
+                {
+                    "match": "([a-z-]+(@[a-z-]+)?)\\s*=.*$",
+                    "name": "__STYLE_INVALID__",
+                    "comment": "A common mistake - property list style pair in property group."
+                },
                 "__PROP_GROUP_PATTERNS__"
             ]
         },


### PR DESCRIPTION
Prevent a common mistake of using the property list style pair (`a = b, b = c`) in a property group.
This often happens when converting a property list to a property group.

<img width="288" alt="Screen Shot 2023-01-16 at 11 55 32 pm" src="https://user-images.githubusercontent.com/1925108/212683207-524efddf-e958-4892-94d3-bc0011873bbd.png">
