### PR TITLE
Variable completion

### DIFF
--- a/src/DiagnosticCollector.ts
+++ b/src/DiagnosticCollector.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import { PropConfigStore } from './PropConfigStore';
 import { PropTarget, PropTargetKind } from "./PropTarget";
 import { PropRange } from './PropGroupParser';
+import { unquote } from './utils';
 
 export abstract class DiagnosticCollector {
     protected readonly document: vscode.TextDocument;
@@ -69,12 +70,4 @@ export abstract class DiagnosticCollector {
             });
         }
     }
-}
-
-function unquote(value: string): string {
-    if (value.length >= 2 && value[0] == value[value.length - 1] && (value[0] == '"' || value[0] == "'")) {
-        value = value.substring(1, value.length - 1);
-        value = value.replace(/\\(.)/g, '$1');
-    }
-    return value;
 }

--- a/src/DiagnosticCollector.ts
+++ b/src/DiagnosticCollector.ts
@@ -60,7 +60,7 @@ export abstract class DiagnosticCollector {
         }
 
         const documentPath = this.document.fileName;
-        const error = valueSpec.verify(name, value, documentPath);
+        const error = valueSpec.verify(value, documentPath);
         if (error) {
             this.diagnostics.push({
                 message: error.message,

--- a/src/DiagnosticCollector.ts
+++ b/src/DiagnosticCollector.ts
@@ -27,7 +27,7 @@ export abstract class DiagnosticCollector {
 
     abstract processLine(line: number, lineText: string, isContinued: boolean): void;
 
-    verifyProperty(target: PropTarget, propRange: PropRange): void {
+    checkProp(target: PropTarget, propRange: PropRange): void {
         const name = this.document.getText(propRange.nameRange);
         const valueSpec = PropConfigStore.getPropValueSpec(target, name);
 
@@ -60,11 +60,11 @@ export abstract class DiagnosticCollector {
         }
 
         const documentPath = this.document.fileName;
-        const error = valueSpec.verify(value, documentPath);
-        if (error) {
+        const result = valueSpec.verify(value, documentPath);
+        if (!result.success) {
             this.diagnostics.push({
-                message: error.message,
                 range: propRange.valueRange,
+                message: result.errorMessage ?? `"${value}" is not valid for "${name}" here.`,
                 severity: vscode.DiagnosticSeverity.Error
             });
         }

--- a/src/PropCompletionItemProvider.ts
+++ b/src/PropCompletionItemProvider.ts
@@ -64,12 +64,12 @@ export class PropCompletionItemProvider {
             }
             return suggestions.map((suggestion, index) => {
                 const item = (() => {
-                    if (!suggestion.isSnippet && suggestion.label !== suggestion.text) {
+                    if (!suggestion.isSnippet && (suggestion.hint || suggestion.label !== suggestion.text)) {
                         const label = suggestion.label;
-                        const description = suggestion.text;
-                        return new vscode.CompletionItem({ label, description }, suggestion.kind);
+                        const description = suggestion.hint ?? suggestion.text;
+                        return new vscode.CompletionItem({ label, description }, suggestion.icon);
                     }
-                    return new vscode.CompletionItem(suggestion.label, suggestion.kind);
+                    return new vscode.CompletionItem(suggestion.label, suggestion.icon);
                 })();
 
                 if (suggestion.isSnippet) {

--- a/src/PropCompletionItemProvider.ts
+++ b/src/PropCompletionItemProvider.ts
@@ -56,7 +56,7 @@ export class PropCompletionItemProvider {
         console.log(`property value: name=${context.name}, valuePrefix=${context.valuePrefix}`);
 
         const propValueSpec = PropConfigStore.getPropValueSpec(context.target, context.name);
-        let suggestions = propValueSpec?.getSuggestions(this.document.fileName);
+        let suggestions = propValueSpec?.getSuggestions(this.triggerChar, this.document.fileName);
         if (suggestions) {
             if (context.valuePrefix) {
                 const prefix = context.valuePrefix;

--- a/src/PropCompletionItemProvider.ts
+++ b/src/PropCompletionItemProvider.ts
@@ -78,7 +78,7 @@ export class PropCompletionItemProvider {
                 else if (this.triggerChar === ':') {
                     item.insertText = ' ' + suggestion.text;
                 }
-                else if (context.valuePrefix == '~' || context.valuePrefix == '~/') {
+                else if (context.valuePrefix === '$' || context.valuePrefix === '~' || context.valuePrefix === '~/') {
                     item.insertText = suggestion.text.substring(context.valuePrefix.length);
                 }
                 else {

--- a/src/PropValueSpec.ts
+++ b/src/PropValueSpec.ts
@@ -136,22 +136,25 @@ export class PropValueSpec {
                     suggestions.push(makeSuggestion(PropValueSuggestionIcon.File, imageName));
                 });
             }
-            // else if (category == '#color') {
-            //     suggestions.push(makeSuggestion(PropValueSuggestionIcon.Color, 'black - #rrggbb', '#000000'));
-            //     suggestions.push(makeSuggestion(PropValueSuggestionIcon.Color, 'white - #rrggbb', '#ffffff'));
-            //     suggestions.push(makeSuggestion(PropValueSuggestionIcon.Color, 'black - #rrggbbaa', '#000000ff'));
-            //     suggestions.push(makeSuggestion(PropValueSuggestionIcon.Color, 'white - #rrggbbaa', '#ffffffff'));
-            //     suggestions.push(makeSnippetSuggestion(
-            //         PropValueSuggestionIcon.Function,
-            //         'rgb($red, $green, $blue)',
-            //         '"rgb(${1:255},${2:255},${3:255})"')
-            //     );
-            //     suggestions.push(makeSnippetSuggestion(
-            //         PropValueSuggestionIcon.Function,
-            //         'rgba($red, $green, $blue, $alpha)',
-            //         '"rgba(${1:255},${2:255},${3:255},${4:0.5})"')
-            //     );
-            // }
+            else if (category == '#color') {
+                // Now that we can suggest variables and we usually have a bunch of color variables in themes.sbss,
+                // these don't seem to help much better.
+
+                /*suggestions.push(makeSuggestion(PropValueSuggestionIcon.Color, 'black - #rrggbb', '#000000'));
+                suggestions.push(makeSuggestion(PropValueSuggestionIcon.Color, 'white - #rrggbb', '#ffffff'));
+                suggestions.push(makeSuggestion(PropValueSuggestionIcon.Color, 'black - #rrggbbaa', '#000000ff'));
+                suggestions.push(makeSuggestion(PropValueSuggestionIcon.Color, 'white - #rrggbbaa', '#ffffffff'));
+                suggestions.push(makeSnippetSuggestion(
+                    PropValueSuggestionIcon.Function,
+                    'rgb($red, $green, $blue)',
+                    '"rgb(${1:255},${2:255},${3:255})"')
+                );
+                suggestions.push(makeSnippetSuggestion(
+                    PropValueSuggestionIcon.Function,
+                    'rgba($red, $green, $blue, $alpha)',
+                    '"rgba(${1:255},${2:255},${3:255},${4:0.5})"')
+                );*/
+            }
             else {
                 assert(false, `WTF? Unknown value category: ${category}`);
             }

--- a/src/SbmlCompletionHandler.ts
+++ b/src/SbmlCompletionHandler.ts
@@ -88,7 +88,8 @@ export class SbmlCompletionHandler {
             },
             ':', ',', '=',
             '(', // inline object/image
-            '~', '/', '.' // image name prefix
+            '~', '/', '.', // image name prefix
+            '$'
         ));
     }
 }

--- a/src/SbmlDiagnosticCollector.ts
+++ b/src/SbmlDiagnosticCollector.ts
@@ -55,7 +55,7 @@ export class SbmlDiagnosticCollector extends DiagnosticCollector {
             if (this.lineKind == LineKind.Directive) {
                 if (this.propParser) {
                     this.propParser.parse(line, 0, text).forEach(
-                        propRange => this.verifyProperty(this.propTarget!, propRange)
+                        propRange => this.checkProp(this.propTarget!, propRange)
                     );
                     this.checkIfLineContinuationMarkerMissing(line, text);
                 }
@@ -83,7 +83,7 @@ export class SbmlDiagnosticCollector extends DiagnosticCollector {
 
                 const offset = directive.propListIndex;
                 this.propParser.parse(line, offset, text).forEach(
-                    propRange => this.verifyProperty(this.propTarget!, propRange)
+                    propRange => this.checkProp(this.propTarget!, propRange)
                 );
                 this.checkIfLineContinuationMarkerMissing(line, text);
             }
@@ -261,7 +261,7 @@ export class SbmlDiagnosticCollector extends DiagnosticCollector {
                 };
                 const propListParser = new PropListParser();
                 propListParser.parse(line, propBeginIndex, propListText).forEach(
-                    propRange => this.verifyProperty(propTarget, propRange)
+                    propRange => this.checkProp(propTarget, propRange)
                 );
             }
 

--- a/src/SbssCompletionHandler.ts
+++ b/src/SbssCompletionHandler.ts
@@ -20,7 +20,7 @@ export class SbssCompletionHandler {
                     }
                 }
             },
-            ':', ',', '='
+            ':', ',', '=', '$'
         ));
     }
 }

--- a/src/SbssDiagnosticCollector.ts
+++ b/src/SbssDiagnosticCollector.ts
@@ -29,7 +29,7 @@ export class SbssDiagnosticCollector extends DiagnosticCollector {
             else {
                 assert(this.propTarget);
                 this.propParser.parse(line, 0, text).forEach(
-                    propRange => this.verifyProperty(this.propTarget!, propRange)
+                    propRange => this.checkProp(this.propTarget!, propRange)
                 );
             }
             return;
@@ -38,7 +38,7 @@ export class SbssDiagnosticCollector extends DiagnosticCollector {
         if (isContinued && this.propParser instanceof PropListParser) {
             assert(this.propTarget);
             this.propParser.parse(line, 0, text).forEach(
-                propRange => this.verifyProperty(this.propTarget!, propRange)
+                propRange => this.checkProp(this.propTarget!, propRange)
             );
             return;
         }
@@ -50,7 +50,7 @@ export class SbssDiagnosticCollector extends DiagnosticCollector {
                 if (context.kind == PropGroupKind.List) {
                     this.propParser = new PropListParser();
                     this.propParser.parse(line, text.indexOf(':') + 1, text).forEach(
-                        propRange => this.verifyProperty(this.propTarget!, propRange)
+                        propRange => this.checkProp(this.propTarget!, propRange)
                     );
                 }
                 else {

--- a/src/SyntaxAnalyser.ts
+++ b/src/SyntaxAnalyser.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { SbmlDiagnosticCollector } from './SbmlDiagnosticCollector';
 import { SbssDiagnosticCollector } from './SbssDiagnosticCollector';
+import { VariableRepository } from './VariableRepository';
 
 export class SyntaxAnalyser {
     static register(context: vscode.ExtensionContext): void {
@@ -52,8 +53,10 @@ export class SyntaxAnalyser {
 
     private updateDiagnostics(document: vscode.TextDocument): void {
         const diagnosticCollector = (() => {
-            if (document.fileName.endsWith('.sbml'))
+            if (document.fileName.endsWith('.sbml')) {
+                VariableRepository.getVariables(document.fileName); // TEST ONLY - DO NOT MERGE
                 return new SbmlDiagnosticCollector(document);
+            }
             if (document.fileName.endsWith('.sbss'))
                 return new SbssDiagnosticCollector(document);
         })();

--- a/src/SyntaxAnalyser.ts
+++ b/src/SyntaxAnalyser.ts
@@ -1,7 +1,6 @@
 import * as vscode from 'vscode';
 import { SbmlDiagnosticCollector } from './SbmlDiagnosticCollector';
 import { SbssDiagnosticCollector } from './SbssDiagnosticCollector';
-import { VariableRepository } from './VariableRepository';
 
 export class SyntaxAnalyser {
     static register(context: vscode.ExtensionContext): void {
@@ -54,11 +53,11 @@ export class SyntaxAnalyser {
     private updateDiagnostics(document: vscode.TextDocument): void {
         const diagnosticCollector = (() => {
             if (document.fileName.endsWith('.sbml')) {
-                VariableRepository.getVariables(document.fileName); // TEST ONLY - DO NOT MERGE
                 return new SbmlDiagnosticCollector(document);
             }
-            if (document.fileName.endsWith('.sbss'))
+            if (document.fileName.endsWith('.sbss')) {
                 return new SbssDiagnosticCollector(document);
+            }
         })();
         if (diagnosticCollector) {
             this.collection.set(document.uri, diagnosticCollector.collect());

--- a/src/VariableCache.ts
+++ b/src/VariableCache.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'fs';
 import * as vscode from 'vscode';
 import * as path from 'path';
 import { assert } from 'console';
+import { unquote } from './utils';
 
 const VARIABLE_DEFINITION_PREFIX = /^\s*\$([A-Z_]+)\s*=/;
 const IMPORT_PATTERN = /^\s*import\s+"?([\w-]+\.sbss)"?/;
@@ -107,7 +108,7 @@ export class VariableCache {
                     let m;
                     if (m = text.match(VARIABLE_DEFINITION_PREFIX)) {
                         const name = m[1];
-                        const value = text.substring(text.indexOf('=') + 1).trim();
+                        const value = unquote(text.substring(text.indexOf('=') + 1).trim());
                         if (value.length == 0)
                             return;
 

--- a/src/VariableCache.ts
+++ b/src/VariableCache.ts
@@ -7,8 +7,6 @@ import { unquote } from './utils';
 const VARIABLE_DEFINITION_PREFIX = /^\s*\$([A-Z_]+)\s*=/;
 const IMPORT_PATTERN = /^\s*import\s+"?([\w-]+\.sbss)"?/;
 
-//export type VariableValues = Map</*name*/ string, /*values*/ string[]>;
-
 export class VariableValues {
     private readonly map = new Map<string, string[]>();
 

--- a/src/VariableCache.ts
+++ b/src/VariableCache.ts
@@ -11,6 +11,10 @@ const IMPORT_PATTERN = /^\s*import\s+"?([\w-]+\.sbss)"?/;
 export class VariableValues {
     private readonly map = new Map<string, string[]>();
 
+    get size(): number {
+        return this.map.size;
+    }
+
     add(name: string, value: string): void {
         const values = this.map.get(name) ?? [];
         if (!values.includes(value)) {
@@ -31,7 +35,7 @@ export class VariableValues {
 type VariableMap = Map</*filePath*/ string, VariableValues>;
 type DependencyMap = Map</*filePath*/ string, /*dependentFilePaths*/ string[]>;
 
-export class VariableRepository {
+export class VariableCache {
     static init(context: vscode.ExtensionContext) {
         const watcher = vscode.workspace.createFileSystemWatcher('**/*.sbss', /*ignoreCreationEvents*/ true);
         watcher.onDidChange(event => this.removeCache(event.fsPath));

--- a/src/VariableRepository.ts
+++ b/src/VariableRepository.ts
@@ -1,0 +1,137 @@
+import { readFileSync } from 'fs';
+import * as vscode from 'vscode';
+import * as path from 'path';
+import { assert } from 'console';
+
+const VARIABLE_DEFINITION_PREFIX = /^\s*\$([A-Z_]+)\s*=/;
+const IMPORT_PATTERN = /^\s*import\s+"?([\w-]+\.sbss)"?/;
+
+//export type VariableValues = Map</*name*/ string, /*values*/ string[]>;
+
+export class VariableValues {
+    private readonly map = new Map<string, string[]>();
+
+    add(name: string, value: string): void {
+        const values = this.map.get(name) ?? [];
+        if (!values.includes(value)) {
+            values.push(value);
+            this.map.set(name, values);
+        }
+    }
+
+    merge(other: VariableValues): void {
+        other.forEach((values, name) => this.map.set(name, values));
+    }
+
+    forEach(callback: (values: string[], name: string) => void): void {
+        this.map.forEach(callback);
+    }
+}
+
+type VariableMap = Map</*filePath*/ string, VariableValues>;
+type DependencyMap = Map</*filePath*/ string, /*dependentFilePaths*/ string[]>;
+
+export class VariableRepository {
+    static init(context: vscode.ExtensionContext) {
+        const watcher = vscode.workspace.createFileSystemWatcher('**/*.sbss', /*ignoreCreationEvents*/ true);
+        watcher.onDidChange(event => this.removeCache(event.fsPath));
+        watcher.onDidDelete(event => this.removeCache(event.fsPath));
+        context.subscriptions.push(watcher);
+    }
+
+    private static cache: VariableMap = new Map();
+    private static depencencyMap: DependencyMap = new Map();
+
+    static getVariables(documentPath: string): VariableValues {
+        assert(documentPath.endsWith('.sbml'));
+
+        const filePath = documentPath.substring(0, documentPath.length - 4) + 'sbss';
+        // console.log(`======= ${filePath} ========`);
+        // this.getValueMap(filePath).forEach((values, name) => {
+        //     console.log(`${name}: ${values}`);
+        // });
+        return this.getValueMap(filePath);
+    }
+
+    private static removeCache(filePath: string) {
+
+        console.log(`${filePath} has changed. Cache invalidated.`);
+
+        // invalidate cached variables
+        this.cache.delete(filePath);
+
+        // if filePath was dependening on other files, clear that.
+        // it will be re-parsed and re
+        this.depencencyMap.forEach((files, _) => {
+            const index = files.indexOf(filePath);
+            if (index >= 0) {
+                files.splice(index, 1);
+            }
+        });
+
+        const dependentFiles = this.depencencyMap.get(filePath);
+        if (dependentFiles) {
+            console.log('Also invalidating cache for the following files:');
+            dependentFiles.forEach(filePath => {
+                console.log(`- ${filePath}`);
+                this.removeCache(filePath);
+            });
+        }
+    }
+
+    private static parsingFiles = new Set<string>(); // recursive import detection
+
+    private static getValueMap(filePath: string): VariableValues {
+        let valueMap = this.cache.get(filePath);
+        if (!valueMap) {
+            valueMap = this.parseValueMap(filePath);
+            this.cache.set(filePath, valueMap);
+        }
+        return valueMap;
+    }
+
+    private static parseValueMap(filePath: string): VariableValues {
+
+        const valueMap = new VariableValues();
+
+        if (!this.parsingFiles.has(filePath)) {
+            this.parsingFiles.add(filePath);
+
+            try {
+                const content = readFileSync(filePath, 'utf-8');
+                content.split(/\r?\n/).forEach((text, line) => {
+                    let m;
+                    if (m = text.match(VARIABLE_DEFINITION_PREFIX)) {
+                        const name = m[1];
+                        const value = text.substring(text.indexOf('=') + 1).trim();
+                        if (value.length == 0)
+                            return;
+
+                        valueMap.add(name, value);
+                    }
+                    else if (m = text.match(IMPORT_PATTERN)) {
+                        const fileName = m[1];
+                        const importFilePath = filePath.substring(0, filePath.lastIndexOf(path.sep) + 1) + fileName;
+                        valueMap.merge(this.getValueMap(importFilePath));
+
+                        this.updateDependencyMap(importFilePath, filePath);
+                    }
+                });
+            } catch (e) {
+                // NOOP
+            }
+
+            this.parsingFiles.delete(filePath);
+        }
+
+        return valueMap;
+    }
+
+    private static updateDependencyMap(importeePath: string, importerPath: string) {
+        const dependentFilePaths = this.depencencyMap.get(importeePath) ?? [];
+        if (!dependentFilePaths.includes(importerPath)) {
+            dependentFilePaths.push(importerPath);
+            this.depencencyMap.set(importeePath, dependentFilePaths);
+        }
+    }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,12 +4,12 @@ import { SbmlCompletionHandler } from './SbmlCompletionHandler';
 import { SyntaxAnalyser } from './SyntaxAnalyser';
 import { PropConfigStore } from './PropConfigStore';
 import { MediaRepository } from './MediaRepository';
-import { VariableRepository } from './VariableRepository';
+import { VariableCache } from './VariableCache';
 
 export function activate(context: ExtensionContext) {
     PropConfigStore.init(context);
     MediaRepository.init(context);
-    VariableRepository.init(context);
+    VariableCache.init(context);
 
     SyntaxAnalyser.register(context);
     SbssCompletionHandler.register(context);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,10 +4,13 @@ import { SbmlCompletionHandler } from './SbmlCompletionHandler';
 import { SyntaxAnalyser } from './SyntaxAnalyser';
 import { PropConfigStore } from './PropConfigStore';
 import { MediaRepository } from './MediaRepository';
+import { VariableRepository } from './VariableRepository';
 
 export function activate(context: ExtensionContext) {
     PropConfigStore.init(context);
     MediaRepository.init(context);
+    VariableRepository.init(context);
+
     SyntaxAnalyser.register(context);
     SbssCompletionHandler.register(context);
     SbmlCompletionHandler.register(context);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,8 @@
+
+export function unquote(value: string): string {
+    if (value.length >= 2 && value[0] == value[value.length - 1] && (value[0] == '"' || value[0] == "'")) {
+        value = value.substring(1, value.length - 1);
+        value = value.replace(/\\(.)/g, '$1');
+    }
+    return value;
+}


### PR DESCRIPTION
## Variable suggestions in property value

- Variables will be suggested in the auto-completion pop-up when:
   - The property has validation rules -- `values`, `value-regex`, or `value-category`
   - User triggers completion with '$'

   Without this, we will end up suggesting all variables for properties with no validation rules.

- Given VSCode doesn't have enough context, variables can have multiple "possible" values. In this case, a variable is valid for a property if any one of the possible values is valid.
  ```
  if $SCREEN_WIDTH > 4.7
    $_WELCOME_TEXT_ALIGN = "center"
  else
    $_WELCOME_TEXT_ALIGN = "left"
  end
   ```
![Screen Recording 2023-02-02 at 9 58 30 am](https://user-images.githubusercontent.com/1925108/216185242-74e199d1-165f-4aa8-bbad-13cae87a17ac.gif)

