### PR TITLE
Value category: #function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
         "": {
             "name": "vscode-jamkit",
             "version": "0.1.4",
+            "dependencies": {
+                "acorn": "^8.8.2"
+            },
             "devDependencies": {
                 "@types/glob": "^8.0.0",
                 "@types/mocha": "^10.0.1",
@@ -374,10 +377,9 @@
             }
         },
         "node_modules/acorn": {
-            "version": "8.8.1",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
-            "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
-            "dev": true,
+            "version": "8.8.2",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
+            "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -2736,10 +2738,9 @@
             }
         },
         "acorn": {
-            "version": "8.8.1",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
-            "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
-            "dev": true
+            "version": "8.8.2",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
+            "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw=="
         },
         "acorn-jsx": {
             "version": "5.3.2",

--- a/package.json
+++ b/package.json
@@ -90,5 +90,8 @@
         "glob": "^8.0.3",
         "mocha": "^10.1.0",
         "typescript": "^4.9.3"
+    },
+    "dependencies": {
+        "acorn": "^8.8.2"
     }
 }

--- a/src/FuncNameCache.ts
+++ b/src/FuncNameCache.ts
@@ -48,18 +48,13 @@ export class FuncNameCache {
                 (program.body as acorn.Node[]).forEach(node => {
                     console.log(node);
                     if (node.type === 'FunctionDeclaration') {
-                        const funcName = getNodeIdName(node);
-                        if (funcName)
-                            funcNames.push(funcName);
+                        funcNames.push(getNodeIdName(node));
                     }
                     else if (node.type === 'VariableDeclaration' && 'declarations' in node) {
-                        (node.declarations as acorn.Node[]).forEach(node => {
-                            if (node.type !== 'VariableDeclarator')
-                                return;
-                            if ('init' in node && node.init instanceof acorn.Node && node.init.type === 'ArrowFunctionExpression') {
-                                const funcName = getNodeIdName(node);
-                                if (funcName)
-                                    funcNames.push(funcName);
+                        const varDecls = node.declarations as acorn.Node[];
+                        varDecls.forEach(node => {
+                            if (isArrowFuncInitDeclarator(node)) {
+                                funcNames.push(getNodeIdName(node));
                             }
                         });
                     }
@@ -74,9 +69,17 @@ export class FuncNameCache {
     }
 }
 
-function getNodeIdName(node: acorn.Node): string | undefined {
+function isArrowFuncInitDeclarator(node: acorn.Node): boolean {
+    if (node.type !== 'VariableDeclarator')
+        return false;
+    return 'init' in node && node.init instanceof acorn.Node && node.init.type === 'ArrowFunctionExpression';
+}
+
+function getNodeIdName(node: acorn.Node): string {
     if ('id' in node && node.id instanceof acorn.Node &&
         'name' in node.id && typeof node.id.name === 'string') {
         return node.id.name;
     }
+    assert(false);
+    return '?';
 }

--- a/src/FuncNameCache.ts
+++ b/src/FuncNameCache.ts
@@ -2,6 +2,9 @@ import { assert } from 'console';
 import { readFileSync } from 'fs';
 import * as vscode from 'vscode';
 
+/**
+ * Keeps top-level function names in memory for *.js files.
+ */
 export class FuncNameCache {
     static init(context: vscode.ExtensionContext) {
         const watcher = vscode.workspace.createFileSystemWatcher('**/*.js', /*ignoreCreationEvents*/ true);

--- a/src/FuncNameCache.ts
+++ b/src/FuncNameCache.ts
@@ -53,7 +53,7 @@ export class FuncNameCache {
                     else if (node.type === 'VariableDeclaration' && 'declarations' in node) {
                         const varDecls = node.declarations as acorn.Node[];
                         varDecls.forEach(node => {
-                            if (isArrowFuncInitDeclarator(node)) {
+                            if (isFuncInitDeclarator(node)) {
                                 funcNames.push(getNodeIdName(node));
                             }
                         });
@@ -69,10 +69,15 @@ export class FuncNameCache {
     }
 }
 
-function isArrowFuncInitDeclarator(node: acorn.Node): boolean {
+function isFuncInitDeclarator(node: acorn.Node): boolean {
     if (node.type !== 'VariableDeclarator')
         return false;
-    return 'init' in node && node.init instanceof acorn.Node && node.init.type === 'ArrowFunctionExpression';
+
+    if ('init' in node && node.init instanceof acorn.Node) {
+        return node.init.type === 'FunctionExpression' || node.init.type === 'ArrowFunctionExpression';
+    }
+
+    return false;
 }
 
 function getNodeIdName(node: acorn.Node): string {

--- a/src/FuncNameCache.ts
+++ b/src/FuncNameCache.ts
@@ -1,0 +1,57 @@
+import { assert } from 'console';
+import { readFileSync } from 'fs';
+import * as vscode from 'vscode';
+
+export class FuncNameCache {
+    static init(context: vscode.ExtensionContext) {
+        const watcher = vscode.workspace.createFileSystemWatcher('**/*.js', /*ignoreCreationEvents*/ true);
+        watcher.onDidChange(event => this.removeCache(event.fsPath));
+        watcher.onDidDelete(event => this.removeCache(event.fsPath));
+        context.subscriptions.push(watcher);
+    }
+
+    private static cache = new Map<string, string[]>();
+
+    static getFuncNames(documentPath: string): string[] {
+        assert(documentPath.endsWith('.sbss') || documentPath.endsWith('.sbml'));
+
+        const scriptFilePath = documentPath.substring(0, documentPath.length - 4) + 'js';
+
+        let funcNames = this.cache.get(scriptFilePath);
+        if (!funcNames) {
+            funcNames = this.parseFuncNames(scriptFilePath);
+            this.cache.set(scriptFilePath, funcNames);
+        }
+        return funcNames;
+    }
+
+    private static removeCache(filePath: string) {
+
+        console.log(`${filePath} has changed. Cache invalidated.`);
+
+        // invalidate cached variables
+        this.cache.delete(filePath);
+    }
+
+    private static parseFuncNames(filePath: string): string[] {
+
+        const FUNC_DEF_PATTERN = /^\s*function\s+(\w[\w\d]+)\s*\(+/;
+
+        const funcNames: string[] = [];
+
+        try {
+            const content = readFileSync(filePath, 'utf-8');
+            content.split(/\r?\n/).forEach(text => {
+                const m = text.match(FUNC_DEF_PATTERN);
+                if (m) {
+                    funcNames.push(m[1]);
+                }
+            });
+        }
+        catch (e) {
+            console.error(e);
+        }
+
+        return funcNames;
+    }
+}

--- a/src/FuncNameCache.ts
+++ b/src/FuncNameCache.ts
@@ -35,14 +35,14 @@ export class FuncNameCache {
 
     private static parseFuncNames(filePath: string): string[] {
 
-        const FUNC_DEF_PATTERN = /^function\s+(\w[\w\d]+)\s*\(+/;
+        const TOP_LEVEL_FUNC_DEF = /^function\s+(\w[\w\d]+)\s*\(+/;
 
         const funcNames: string[] = [];
 
         try {
             const content = readFileSync(filePath, 'utf-8');
             content.split(/\r?\n/).forEach(text => {
-                const m = text.match(FUNC_DEF_PATTERN);
+                const m = text.match(TOP_LEVEL_FUNC_DEF);
                 if (m) {
                     funcNames.push(m[1]);
                 }

--- a/src/FuncNameCache.ts
+++ b/src/FuncNameCache.ts
@@ -1,6 +1,7 @@
 import { assert } from 'console';
 import { readFileSync } from 'fs';
 import * as vscode from 'vscode';
+import * as acorn from 'acorn';
 
 /**
  * Keeps top-level function names in memory for *.js files.
@@ -38,23 +39,44 @@ export class FuncNameCache {
 
     private static parseFuncNames(filePath: string): string[] {
 
-        const TOP_LEVEL_FUNC_DEF = /^function\s+(\w[\w\d]+)\s*\(+/;
-
         const funcNames: string[] = [];
 
         try {
             const content = readFileSync(filePath, 'utf-8');
-            content.split(/\r?\n/).forEach(text => {
-                const m = text.match(TOP_LEVEL_FUNC_DEF);
-                if (m) {
-                    funcNames.push(m[1]);
-                }
-            });
+            const program = acorn.parse(content, { ecmaVersion: 'latest' });
+            if ('body' in program) {
+                (program.body as acorn.Node[]).forEach(node => {
+                    console.log(node);
+                    if (node.type === 'FunctionDeclaration') {
+                        const funcName = getNodeIdName(node);
+                        if (funcName)
+                            funcNames.push(funcName);
+                    }
+                    else if (node.type === 'VariableDeclaration' && 'declarations' in node) {
+                        (node.declarations as acorn.Node[]).forEach(node => {
+                            if (node.type !== 'VariableDeclarator')
+                                return;
+                            if ('init' in node && node.init instanceof acorn.Node && node.init.type === 'ArrowFunctionExpression') {
+                                const funcName = getNodeIdName(node);
+                                if (funcName)
+                                    funcNames.push(funcName);
+                            }
+                        });
+                    }
+                });
+            }
         }
         catch (e) {
             console.error(e);
         }
 
         return funcNames;
+    }
+}
+
+function getNodeIdName(node: acorn.Node): string | undefined {
+    if ('id' in node && node.id instanceof acorn.Node &&
+        'name' in node.id && typeof node.id.name === 'string') {
+        return node.id.name;
     }
 }

--- a/src/FuncNameCache.ts
+++ b/src/FuncNameCache.ts
@@ -35,7 +35,7 @@ export class FuncNameCache {
 
     private static parseFuncNames(filePath: string): string[] {
 
-        const FUNC_DEF_PATTERN = /^\s*function\s+(\w[\w\d]+)\s*\(+/;
+        const FUNC_DEF_PATTERN = /^function\s+(\w[\w\d]+)\s*\(+/;
 
         const funcNames: string[] = [];
 

--- a/src/JamkitExtension.ts
+++ b/src/JamkitExtension.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { PropConfigStore } from './PropConfigStore';
 import { MediaRepository } from './MediaRepository';
+import { FuncNameCache } from './FuncNameCache';
 import { VariableCache } from './VariableCache';
 import { toString } from './utils';
 import { SbmlSyntaxAnalyser } from './SbmlSyntaxAnalyser';
@@ -11,6 +12,7 @@ import { SbmlCompletionHandler } from './SbmlCompletionHandler';
 export class JamkitExtension {
     static init(context: vscode.ExtensionContext): void {
 
+        FuncNameCache.init(context);
         VariableCache.init(context);
         PropConfigStore.init(context);
         MediaRepository.init(context);

--- a/src/PropConfigStore.ts
+++ b/src/PropConfigStore.ts
@@ -123,7 +123,7 @@ export class PropConfigStore {
             }
         }
 
-        if (propName === 'script' || propName.startsWith('script-when-')) {
+        if (propName === 'script' || propName.startsWith('script-when-') || propName.endsWith('-script')) {
             return PropValueSpec.from('#function');
         }
     }

--- a/src/PropConfigStore.ts
+++ b/src/PropConfigStore.ts
@@ -122,6 +122,10 @@ export class PropConfigStore {
                 return valueSpec;
             }
         }
+
+        if (propName.startsWith('script-when-')) {
+            return PropValueSpec.from('#function');
+        }
     }
 
     private static getPropFileSequence(target: PropTarget): string[] {

--- a/src/PropConfigStore.ts
+++ b/src/PropConfigStore.ts
@@ -123,7 +123,7 @@ export class PropConfigStore {
             }
         }
 
-        if (target.kind !== PropTargetKind.Text && propName.startsWith('script-when-')) {
+        if (propName === 'script' || propName.startsWith('script-when-')) {
             return PropValueSpec.from('#function');
         }
     }

--- a/src/PropConfigStore.ts
+++ b/src/PropConfigStore.ts
@@ -123,7 +123,7 @@ export class PropConfigStore {
             }
         }
 
-        if (propName.startsWith('script-when-')) {
+        if (target.kind !== PropTargetKind.Text && propName.startsWith('script-when-')) {
             return PropValueSpec.from('#function');
         }
     }

--- a/src/PropValueSpec.ts
+++ b/src/PropValueSpec.ts
@@ -114,7 +114,9 @@ export class PropValueSpec {
                     return { success: true };
                 }
 
-                errorMessage = `Unknown function name.`;
+                errorMessage =
+                    `Unknown function name. Please make sure '${value}' is a top-level function name ` +
+                    `defined in '${documentPath.substring(0, documentPath.length - 4) + 'js'}'.`;
             }
             else if (category == '#color') {
                 if (isColorText(value)) {

--- a/src/VariableCache.ts
+++ b/src/VariableCache.ts
@@ -1,7 +1,6 @@
 import { readFileSync } from 'fs';
 import * as vscode from 'vscode';
 import * as path from 'path';
-import { assert } from 'console';
 import { parseSbssVariableDefinition } from './patterns';
 
 const IMPORT_PATTERN = /^\s*import\s+"?([\w-]+\.sbss)"?/;

--- a/src/test/suite/Expression.test.ts
+++ b/src/test/suite/Expression.test.ts
@@ -54,7 +54,7 @@ suite('LengthChecker', () => {
     test('paran mismatch', () => {
         const r = check('(1 + 3');
         assert.strictEqual(r.success, false);
-        assert.strictEqual(r.message, 'Unexpected end of expression: (expected RPARAN)');
+        assert.strictEqual(r.message, 'Unexpected end of expression: (expected RPAREN)');
     });
 
     test('function sanity', () => {


### PR DESCRIPTION
`#function` is done by parsing top-level function names from the matching .js file.

It can parse `func_1` ~ `func_4` in the following code but not `func_5`.
```ts
function func_1() { ... }

const func_2 = function() { ... }

const func_2 = () => { ... };

const func_3 = () => { ... },
      func_4 = () => { ... };

const func_5 = func_1; // <---- this doesn't work.
```

Also, the `#function` value-category automatically applies to the properties that meet the following criteria unless they're defined in the value spec (.json) file.
- property name equals "script"
- property name starts with "script-when-". e.g., "script-when-loaded", "script-when-failed"
- property name ends with "-script". e.g., "data-script", "authorize-script"