### PR TITLE
Value category: #json-filename

### DIFF
--- a/src/JamkitExtension.ts
+++ b/src/JamkitExtension.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { PropConfigStore } from './PropConfigStore';
-import { MediaRepository } from './MediaRepository';
+import { ResourceRepository } from './ResourceRepository';
 import { FuncNameCache } from './FuncNameCache';
 import { VariableCache } from './VariableCache';
 import { toString } from './utils';
@@ -15,7 +15,7 @@ export class JamkitExtension {
         FuncNameCache.init(context);
         VariableCache.init(context);
         PropConfigStore.init(context);
-        MediaRepository.init(context);
+        ResourceRepository.init(context);
         SbssCompletionHandler.init(context);
         SbmlCompletionHandler.init(context);
 

--- a/src/MediaRepository.ts
+++ b/src/MediaRepository.ts
@@ -5,9 +5,10 @@ import { readdirSync, existsSync } from 'fs';
 const IMAGE_FOLDER_NAME = 'Images';
 const AUDIO_FOLDER_NAME = 'Audios';
 const VIDEO_FOLDER_NAME = 'Videos';
+const TEXT_FOLDER_NAME = 'Texts';
 
 export enum MediaKind {
-    Image, Audio, Video
+    Image, Audio, Video, Text
 }
 
 export class MediaRepository {
@@ -32,7 +33,8 @@ export class MediaRepository {
         const mediaFolderName = (() => {
             if (media == MediaKind.Image) return IMAGE_FOLDER_NAME;
             if (media == MediaKind.Audio) return AUDIO_FOLDER_NAME;
-            return VIDEO_FOLDER_NAME;
+            if (media == MediaKind.Video) return VIDEO_FOLDER_NAME;
+            return TEXT_FOLDER_NAME;
         })();
 
         const mediaNames: string[] = [];
@@ -65,8 +67,8 @@ export class MediaRepository {
             }
         })();
         if (rootMediaDirPath) {
-            this.getMediaNamesAtDirPath(rootMediaDirPath).forEach(imageName => {
-                mediaNames.push('~/' + imageName);
+            this.getMediaNamesAtDirPath(rootMediaDirPath).forEach(mediaName => {
+                mediaNames.push('~/' + mediaName);
             });
         }
 
@@ -105,6 +107,7 @@ function isMediaFilePath(filePath: string): boolean {
         case IMAGE_FOLDER_NAME:
         case AUDIO_FOLDER_NAME:
         case VIDEO_FOLDER_NAME:
+        case TEXT_FOLDER_NAME:
             return true;
         default:
             return false;

--- a/src/PropValueSpec.ts
+++ b/src/PropValueSpec.ts
@@ -1,6 +1,6 @@
 import { assert } from "console";
 import { CompletionItemKind as PropValueSuggestionIcon } from "vscode";
-import { MediaKind, MediaRepository } from "./MediaRepository";
+import { MediaKind, ResourceRepository } from "./ResourceRepository";
 import { VariableCache } from "./VariableCache";
 import { isColorText } from "./utils";
 import { checkLength } from "./Expression";
@@ -115,7 +115,7 @@ export class PropValueSpec {
 
         for (const category of this.categories) {
             if (isFileValueCategory(category)) {
-                if (MediaRepository.enumerateMediaNames(toResouceKind(category), documentPath).includes(value)) {
+                if (ResourceRepository.enumerateMediaNames(toResouceKind(category), documentPath).includes(value)) {
                     return { success: true };
                 }
 
@@ -181,7 +181,7 @@ export class PropValueSpec {
 
         for (const category of this.categories) {
             if (isFileValueCategory(category)) {
-                MediaRepository.enumerateMediaNames(toResouceKind(category), documentPath).forEach(imageName => {
+                ResourceRepository.enumerateMediaNames(toResouceKind(category), documentPath).forEach(imageName => {
                     suggestions.push(makeSuggestion(PropValueSuggestionIcon.File, imageName));
                 });
             }

--- a/src/PropValueSpec.ts
+++ b/src/PropValueSpec.ts
@@ -6,10 +6,22 @@ import { isColorText } from "./utils";
 import { checkLength } from "./Expression";
 import { FuncNameCache } from "./FuncNameCache";
 
+type FileValueCategory = '#image-filename' | '#audio-filename' | '#video-filename' | '#json-filename';
+
+function isFileValueCategory(s: string): s is FileValueCategory {
+    return (
+        s === '#image-filename' ||
+        s === '#audio-filename' ||
+        s === '#video-filename' ||
+        s === '#json-filename'
+    );
+}
+
 const KNOWN_CATEGORIES: string[] = [
     '#image-filename',
     '#audio-filename',
     '#video-filename',
+    '#json-filename',
     // '#style-name',
     '#4-sided-length',
     '#color',
@@ -102,8 +114,8 @@ export class PropValueSpec {
         }
 
         for (const category of this.categories) {
-            if (category == '#image-filename' || category == '#audio-filename' || category == '#video-filename') {
-                if (MediaRepository.enumerateMediaNames(toMediaKind(category), documentPath).includes(value)) {
+            if (isFileValueCategory(category)) {
+                if (MediaRepository.enumerateMediaNames(toResouceKind(category), documentPath).includes(value)) {
                     return { success: true };
                 }
 
@@ -168,8 +180,8 @@ export class PropValueSpec {
         })() ?? [];
 
         for (const category of this.categories) {
-            if (category == '#image-filename' || category == '#audio-filename' || category == '#video-filename') {
-                MediaRepository.enumerateMediaNames(toMediaKind(category), documentPath).forEach(imageName => {
+            if (isFileValueCategory(category)) {
+                MediaRepository.enumerateMediaNames(toResouceKind(category), documentPath).forEach(imageName => {
                     suggestions.push(makeSuggestion(PropValueSuggestionIcon.File, imageName));
                 });
             }
@@ -227,12 +239,14 @@ function makeSuggestion(kind: PropValueSuggestionIcon, label: string, text?: str
 //     return { label, text, icon: kind, isSnippet: true };
 // }
 
-function toMediaKind(valueCategory: '#image-filename' | '#audio-filename' | '#video-filename'): MediaKind {
+function toResouceKind(valueCategory: FileValueCategory): MediaKind {
     if (valueCategory == '#image-filename')
         return MediaKind.Image;
     if (valueCategory == '#audio-filename')
         return MediaKind.Audio;
-    return MediaKind.Video;
+    if (valueCategory == '#video-filename')
+        return MediaKind.Video;
+    return MediaKind.Text;
 }
 
 function is4SidedLength(value: string): boolean {

--- a/src/PropValueSpec.ts
+++ b/src/PropValueSpec.ts
@@ -1,6 +1,6 @@
 import { assert } from "console";
 import { CompletionItemKind as PropValueSuggestionIcon } from "vscode";
-import { MediaKind, ResourceRepository } from "./ResourceRepository";
+import { ResourceKind, ResourceRepository } from "./ResourceRepository";
 import { VariableCache } from "./VariableCache";
 import { isColorText } from "./utils";
 import { checkLength } from "./Expression";
@@ -115,7 +115,7 @@ export class PropValueSpec {
 
         for (const category of this.categories) {
             if (isFileValueCategory(category)) {
-                if (ResourceRepository.enumerateMediaNames(toResouceKind(category), documentPath).includes(value)) {
+                if (ResourceRepository.enumerateResourceNames(toResouceKind(category), documentPath).includes(value)) {
                     return { success: true };
                 }
 
@@ -181,7 +181,7 @@ export class PropValueSpec {
 
         for (const category of this.categories) {
             if (isFileValueCategory(category)) {
-                ResourceRepository.enumerateMediaNames(toResouceKind(category), documentPath).forEach(imageName => {
+                ResourceRepository.enumerateResourceNames(toResouceKind(category), documentPath).forEach(imageName => {
                     suggestions.push(makeSuggestion(PropValueSuggestionIcon.File, imageName));
                 });
             }
@@ -239,14 +239,14 @@ function makeSuggestion(kind: PropValueSuggestionIcon, label: string, text?: str
 //     return { label, text, icon: kind, isSnippet: true };
 // }
 
-function toResouceKind(valueCategory: FileValueCategory): MediaKind {
+function toResouceKind(valueCategory: FileValueCategory): ResourceKind {
     if (valueCategory == '#image-filename')
-        return MediaKind.Image;
+        return ResourceKind.Image;
     if (valueCategory == '#audio-filename')
-        return MediaKind.Audio;
+        return ResourceKind.Audio;
     if (valueCategory == '#video-filename')
-        return MediaKind.Video;
-    return MediaKind.Text;
+        return ResourceKind.Video;
+    return ResourceKind.Text;
 }
 
 function is4SidedLength(value: string): boolean {

--- a/src/ResourceRepository.ts
+++ b/src/ResourceRepository.ts
@@ -11,7 +11,7 @@ export enum MediaKind {
     Image, Audio, Video, Text
 }
 
-export class MediaRepository {
+export class ResourceRepository {
     static init(context: vscode.ExtensionContext) {
         const globPattern = `**/{${[IMAGE_FOLDER_NAME, AUDIO_FOLDER_NAME, VIDEO_FOLDER_NAME].join(',')}}/*.*`;
         const watcher = vscode.workspace.createFileSystemWatcher(

--- a/src/ResourceRepository.ts
+++ b/src/ResourceRepository.ts
@@ -7,7 +7,7 @@ const AUDIO_FOLDER_NAME = 'Audios';
 const VIDEO_FOLDER_NAME = 'Videos';
 const TEXT_FOLDER_NAME = 'Texts';
 
-export enum MediaKind {
+export enum ResourceKind {
     Image, Audio, Video, Text
 }
 
@@ -26,29 +26,29 @@ export class ResourceRepository {
     }
 
     static enumerateImageNames(documentPath: string): string[] {
-        return this.enumerateMediaNames(MediaKind.Image, documentPath);
+        return this.enumerateResourceNames(ResourceKind.Image, documentPath);
     }
 
-    static enumerateMediaNames(media: MediaKind, documentPath: string): string[] {
-        const mediaFolderName = (() => {
-            if (media == MediaKind.Image) return IMAGE_FOLDER_NAME;
-            if (media == MediaKind.Audio) return AUDIO_FOLDER_NAME;
-            if (media == MediaKind.Video) return VIDEO_FOLDER_NAME;
+    static enumerateResourceNames(kind: ResourceKind, documentPath: string): string[] {
+        const resourceFolderName = (() => {
+            if (kind == ResourceKind.Image) return IMAGE_FOLDER_NAME;
+            if (kind == ResourceKind.Audio) return AUDIO_FOLDER_NAME;
+            if (kind == ResourceKind.Video) return VIDEO_FOLDER_NAME;
             return TEXT_FOLDER_NAME;
         })();
 
-        const mediaNames: string[] = [];
+        const resourceNames: string[] = [];
 
         const pathComponents = documentPath.split(path.sep);
 
-        const currentMediaDirPath = (() => {
+        const currentResDirPath = (() => {
             pathComponents.pop();
-            pathComponents.push(mediaFolderName);
+            pathComponents.push(resourceFolderName);
             return pathComponents.join(path.sep);
         })();
-        mediaNames.push(...this.getMediaNamesAtDirPath(currentMediaDirPath));
+        resourceNames.push(...this.getResourceNamesAtDirPath(currentResDirPath));
 
-        const rootMediaDirPath = (() => {
+        const rootResDirPath = (() => {
             while (pathComponents.length > 0) {
 
                 for (const projectFileName of ['catalog.bon', 'book.bon']) {
@@ -58,7 +58,7 @@ export class ResourceRepository {
                     const projectFilePath = pathComponents.join(path.sep);
                     if (existsSync(projectFilePath)) {
                         pathComponents.pop();
-                        pathComponents.push(mediaFolderName);
+                        pathComponents.push(resourceFolderName);
                         return pathComponents.join(path.sep);
                     }
                 }
@@ -66,43 +66,43 @@ export class ResourceRepository {
                 pathComponents.pop();
             }
         })();
-        if (rootMediaDirPath) {
-            this.getMediaNamesAtDirPath(rootMediaDirPath).forEach(mediaName => {
-                mediaNames.push('~/' + mediaName);
+        if (rootResDirPath) {
+            this.getResourceNamesAtDirPath(rootResDirPath).forEach(name => {
+                resourceNames.push('~/' + name);
             });
         }
 
-        return mediaNames;
+        return resourceNames;
     }
 
-    private static mediaNamesCache = new Map</*dirPath*/ string, /*imageNames*/ string[]>;
+    private static resourceNamesCache = new Map</*dirPath*/ string, /*imageNames*/ string[]>;
 
-    private static getMediaNamesAtDirPath(dirPath: string): string[] {
-        let imageNames = this.mediaNamesCache.get(dirPath);
+    private static getResourceNamesAtDirPath(dirPath: string): string[] {
+        let imageNames = this.resourceNamesCache.get(dirPath);
         if (!imageNames) {
-            const uniqueMediaNames = new Set<string>();
+            const uniqueResNames = new Set<string>();
             readdirSync(dirPath).forEach(filename => {
                 if (filename.startsWith('.'))
                     return;
-                uniqueMediaNames.add(stripAtSuffix(filename));
+                uniqueResNames.add(stripAtSuffix(filename));
             });
-            imageNames = Array.from(uniqueMediaNames);
-            this.mediaNamesCache.set(dirPath, imageNames);
+            imageNames = Array.from(uniqueResNames);
+            this.resourceNamesCache.set(dirPath, imageNames);
         }
         return imageNames;
     }
 
     private static updateCache(filePath: string): void {
-        if (isMediaFilePath(filePath)) {
+        if (isResourceFilePath(filePath)) {
             const pathComponents = filePath.split(path.sep);
             pathComponents.pop();
             const dirPath = pathComponents.join(path.sep);
-            this.mediaNamesCache.delete(dirPath);
+            this.resourceNamesCache.delete(dirPath);
         }
     }
 }
 
-function isMediaFilePath(filePath: string): boolean {
+function isResourceFilePath(filePath: string): boolean {
     switch (filePath.split(path.sep).at(-2)) {
         case IMAGE_FOLDER_NAME:
         case AUDIO_FOLDER_NAME:

--- a/src/SbmlCompletionHandler.ts
+++ b/src/SbmlCompletionHandler.ts
@@ -70,7 +70,7 @@ export class SbmlCompletionHandler {
                             });
                         }
                         else if (context instanceof ImageNameContext) {
-                            let imageNames = ResourceRepository.enumerateImageNames(document.fileName);
+                            let imageNames = ResourceRepository.enumerateImageFileNames(document.fileName);
                             if (context.prefix) {
                                 const prefix = context.prefix;
                                 imageNames = imageNames.filter(imageName => imageName.startsWith(prefix));

--- a/src/SbmlCompletionHandler.ts
+++ b/src/SbmlCompletionHandler.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import { PropCompletionItemProvider } from './PropCompletionItemProvider';
 import { ImageNameContext, ObjectTypeContext, SbmlContextParser } from './SbmlContextParser';
-import { MediaRepository } from './MediaRepository';
+import { ResourceRepository } from './ResourceRepository';
 import { PropConfigStore } from './PropConfigStore';
 
 function shouldSuggestInlineObject(document: vscode.TextDocument, position: vscode.Position, triggerChar: string | undefined): boolean {
@@ -70,7 +70,7 @@ export class SbmlCompletionHandler {
                             });
                         }
                         else if (context instanceof ImageNameContext) {
-                            let imageNames = MediaRepository.enumerateImageNames(document.fileName);
+                            let imageNames = ResourceRepository.enumerateImageNames(document.fileName);
                             if (context.prefix) {
                                 const prefix = context.prefix;
                                 imageNames = imageNames.filter(imageName => imageName.startsWith(prefix));

--- a/src/SbmlSyntaxAnalyser.ts
+++ b/src/SbmlSyntaxAnalyser.ts
@@ -5,7 +5,7 @@ import { PropListParser } from './PropGroupParser';
 import { SyntaxAnalyser } from './SyntaxAnalyser';
 import { PropTarget, PropTargetKind } from "./PropTarget";
 import { PropConfigStore } from './PropConfigStore';
-import { MediaRepository } from './MediaRepository';
+import { ResourceRepository } from './ResourceRepository';
 
 const IF_PATTERN = /^\s*=if\b/;
 const ELIF_PATTERN = /^\s*=elif\b/;
@@ -200,7 +200,7 @@ export class SbmlSyntaxAnalyser extends SyntaxAnalyser {
         }
         else if (directive.kind == DirectiveKind.Image) {
             if (directive.tag != undefined) {
-                if (!MediaRepository.enumerateImageNames(this.document.fileName).includes(directive.tag)) {
+                if (!ResourceRepository.enumerateImageNames(this.document.fileName).includes(directive.tag)) {
                     const offset = text.indexOf(directive.tag, text.indexOf('=') + 6);
                     this.addImageNameDiagnostic(directive.tag, line, offset);
                 }
@@ -247,7 +247,7 @@ export class SbmlSyntaxAnalyser extends SyntaxAnalyser {
             }
             else {
                 assert(m[1] === 'image');
-                const imageNames = MediaRepository.enumerateImageNames(this.document.fileName);
+                const imageNames = ResourceRepository.enumerateImageNames(this.document.fileName);
                 if (!imageNames.includes(tag)) {
                     this.addImageNameDiagnostic(tag, line, textOffset + tagBeginIndex);
                 }

--- a/src/SbmlSyntaxAnalyser.ts
+++ b/src/SbmlSyntaxAnalyser.ts
@@ -200,7 +200,7 @@ export class SbmlSyntaxAnalyser extends SyntaxAnalyser {
         }
         else if (directive.kind == DirectiveKind.Image) {
             if (directive.tag != undefined) {
-                if (!ResourceRepository.enumerateImageNames(this.document.fileName).includes(directive.tag)) {
+                if (!ResourceRepository.enumerateImageFileNames(this.document.fileName).includes(directive.tag)) {
                     const offset = text.indexOf(directive.tag, text.indexOf('=') + 6);
                     this.addImageNameDiagnostic(directive.tag, line, offset);
                 }
@@ -247,7 +247,7 @@ export class SbmlSyntaxAnalyser extends SyntaxAnalyser {
             }
             else {
                 assert(m[1] === 'image');
-                const imageNames = ResourceRepository.enumerateImageNames(this.document.fileName);
+                const imageNames = ResourceRepository.enumerateImageFileNames(this.document.fileName);
                 if (!imageNames.includes(tag)) {
                     this.addImageNameDiagnostic(tag, line, textOffset + tagBeginIndex);
                 }


### PR DESCRIPTION
Generalise `MediaRepository` behaviour so we can support text files such as json.
Unlike other media files, we should specify a suffix (a.k.a. file extension) to enumerate text files.